### PR TITLE
Fix global state initialization by mapping .data and .bss to EWRAM

### DIFF
--- a/docs/memory_initialization.md
+++ b/docs/memory_initialization.md
@@ -1,0 +1,40 @@
+# Global State and Memory Initialization
+
+Unlike modern operating systems, the Game Boy Advance (GBA) has no OS to automatically load executable sections into memory. It boots directly from the read-only Game Pak ROM (`pakrom`). 
+
+When you write standard Zig programs, you might use file-level variables or global state:
+
+```zig
+var spr: Sprite = undefined; // Goes to the .bss section (zero-initialized)
+var dx: i32 = 1;             // Goes to the .data section (has an initial value)
+```
+
+Because ROM is strictly read-only, mutating these variables at runtime will silently fail if they remain in ROM. To support mutable global state on the GBA, these sections must be mapped to system RAM (like EWRAM) and explicitly initialized during the boot process.
+
+## 1. Linker Script (`gba.ld`)
+
+The linker script must direct `.bss` and `.data` symbols to `ewram`. Crucially, `.data` variables need their initial values stored in ROM so they aren't lost when the device loses power. We use `AT>pakrom` to tell the linker: "Set the runtime memory address (VMA) to EWRAM, but store the actual data (LMA) in the Game Pak ROM."
+
+```ld
+    .data : {
+        _sidata = LOADADDR(.data);
+        _sdata = .;
+        *(.data .data.*);
+        _edata = .;
+    } > ewram AT>pakrom
+
+    .bss : {
+        _sbss = .;
+        *(.bss .bss.*);
+        _ebss = .;
+    } > ewram
+```
+
+## 2. Boot Routine (`_boot`)
+
+Before the `main()` function is called, our manual startup assembly (`src/hal/hal.zig`) must physically prepare the memory environment using the boundary symbols (`_sbss`, `_sdata`, etc.) provided by the linker script:
+
+- **`zeroBss()`**: Iterates through the `.bss` block in EWRAM and zeroes out the memory.
+- **`copyDataToEWRAM()`**: Copies the exact byte values from the ROM storage address (`_sidata`) into the designated EWRAM address range (`_sdata` to `_edata`).
+
+If these steps are omitted, `.bss` will contain random garbage data from power-on, and `.data` variables will never receive their initial values, causing the game to behave unpredictably or crash.

--- a/src/hal/gba.ld
+++ b/src/hal/gba.ld
@@ -9,7 +9,7 @@
 /*
  * Memory layout is based on tonc and other documetations. I mainly
  * learn from lokathor.
- * 
+ *
  * 1. https://www.coranac.com/tonc/text/hardware.htm#sec-memory
  * 2. https://lokathor.github.io/gba-from-scratch/ex1.html
  * 3. https://mcyoung.xyz/2021/06/01/linker-script/
@@ -53,7 +53,6 @@ SECTIONS
         . = ALIGN(4);
     } > pakrom
 
-    /*
     .rodata : {
         *(.rodata .rodata.*);
         . = ALIGN(4);
@@ -63,23 +62,22 @@ SECTIONS
         _sidata = LOADADDR(.data);
         . = ALIGN(4);
         _sdata = .;
-        *(.data);
+        *(.data .data.*);
 
         . = ALIGN(4);
         _edata = .;
-    } > iwram AT > pakrom
+    } > ewram AT>pakrom
 
     .bss : {
         . = ALIGN(4);
         _sbss = .;
-        *(.bss);
+        *(.bss .bss.*);
         . = ALIGN(4);
         _ebss = .;
-    } > iwram
+    } > ewram
 
     /DISCARD/ :
     {
         *(.ARM.exidx .ARM.exidx.*);
     }
-    */
 }

--- a/src/hal/hal.zig
+++ b/src/hal/hal.zig
@@ -161,13 +161,28 @@ pub fn setupROMHeader(
     return h;
 }
 
+
 fn zeroBss() void {
     // Clear memory of .bss section
     // (between _sbss and _ebss), filling them to all 0.
+    var dst = @as([*]u8, @ptrCast(&_sbss));
+    const end = @as([*]u8, @ptrCast(&_ebss));
+    while (@intFromPtr(dst) < @intFromPtr(end)) : (dst += 1) {
+        dst[0] = 0;
+    }
 }
+
 
 fn copyDataToEWRAM() void {
     // Copy .data section to EWRAM
+    var src = @as([*]u8, @ptrCast(&_sidata));
+    var dst = @as([*]u8, @ptrCast(&_sdata));
+    const end = @as([*]u8, @ptrCast(&_edata));
+    while (@intFromPtr(dst) < @intFromPtr(end)) {
+        dst[0] = src[0];
+        dst += 1;
+        src += 1;
+    }
 }
 
 fn callUserMain() void {


### PR DESCRIPTION
Fixes #8.

This PR addresses the issue where global state (file-level variables) failed to initialize or update correctly.
1. Updated  to properly map  and  into  and correctly format the  directive.
2. Implemented  and  in  so the GBA properly transfers data initialization from ROM into RAM and zeroes out the BSS section prior to invoking the  entry point.