### PR TITLE
refactor(hal): convert display to module with global state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,8 @@ Zamgba is a self-learning project for Game Boy Advance (GBA) programming using t
 - **Why**: `@hasDecl` is evaluated at compile time and caused an endless loop during boot under certain target configurations. **Do not refactor the boot sequence to use `@hasDecl`**.
 
 ### 3. Register Access and Unit Testing
-- **Avoid Register Writes in Tests**: GBA hardware register writing functions (such as `Display.writeRegister()` which writes directly to `0x04000000`) must **never** be invoked in unit tests.
-- **Pattern**: When testing components like `Display`, only verify their software-side state (e.g., checking `Display.value`). Avoid writing to or reading from actual volatile pointers when executed on host test machines.
+- **Avoid Register Writes in Tests**: GBA hardware register writing functions (such as `display.writeRegister()` which writes directly to `0x04000000`) must **never** be invoked in unit tests.
+- **Pattern**: When testing components like `display`, only verify their software-side state (e.g., checking `display.value`). Avoid writing to or reading from actual volatile pointers when executed on host test machines.
 
 ### 4. Client Integration Requirements
 To successfully use Zamgba in an external/client project:

--- a/demo/engine/joypad_instanced.zig
+++ b/demo/engine/joypad_instanced.zig
@@ -65,8 +65,10 @@ const Game = struct {
 };
 
 export fn main() noreturn {
-    var display = hal.Display.init();
-    display.setMode0().setObject().setObject1D().writeRegister();
+    hal.display.setMode0();
+    hal.display.setObject();
+    hal.display.setObject1D();
+    hal.display.writeRegister();
 
     const spr_width: u32 = 16;
     const spr_height: u32 = 16;

--- a/demo/engine/sprite_engine.zig
+++ b/demo/engine/sprite_engine.zig
@@ -30,8 +30,10 @@ pub fn tick(eng: *engine.Engine) void {
 
 export fn main() noreturn {
     // 1. Initialize Display (We still need to configure the hardware registers initially)
-    var display = hal.Display.init();
-    display.setMode0().setObject().setObject1D().writeRegister();
+    hal.display.setMode0();
+    hal.display.setObject();
+    hal.display.setObject1D();
+    hal.display.writeRegister();
 
     // 2. Initialize high-level sprite state (8x8 square sprite)
     spr = engine.Sprite.init(116, 76, 8, 8);

--- a/demo/engine/sprite_instanced.zig
+++ b/demo/engine/sprite_instanced.zig
@@ -33,8 +33,10 @@ const Game = struct {
 
 export fn main() noreturn {
     // 1. Initialize Display
-    var display = hal.Display.init();
-    display.setMode0().setObject().setObject1D().writeRegister();
+    hal.display.setMode0();
+    hal.display.setObject();
+    hal.display.setObject1D();
+    hal.display.writeRegister();
 
     // 2. Instantiate our game state on the stack
     var game = Game{

--- a/demo/hal/joypad_hal.zig
+++ b/demo/hal/joypad_hal.zig
@@ -13,8 +13,9 @@ export var gameHeader linksection(".gba.header") = hal.setupROMHeader(
 export fn main() noreturn {
     // 1. Initialize Display
     // Set Mode 3 (Bitmap mode) and enable BG2 to draw directly to VRAM.
-    var display = hal.Display.init();
-    display.setMode3().setBackground2().writeRegister();
+    hal.display.setMode3();
+    hal.display.setBackground2();
+    hal.display.writeRegister();
 
     // 2. Initialize Input
     var input = engine.input.InputState{};

--- a/demo/hal/mode3_lines.zig
+++ b/demo/hal/mode3_lines.zig
@@ -31,8 +31,9 @@ export var gameHeader linksection(".gba.header") = hal.setupROMHeader(
 export fn main() noreturn {
     // The example https://www.coranac.com/tonc/text/first.htm
 
-    var display = hal.Display.init();
-    display.setMode3().setBackground2().writeRegister();
+    hal.display.setMode3();
+    hal.display.setBackground2();
+    hal.display.writeRegister();
 
     var ctx = hal.context.Mode3Context.init();
 

--- a/demo/hal/sprite_hal.zig
+++ b/demo/hal/sprite_hal.zig
@@ -15,8 +15,10 @@ export fn main() noreturn {
     // 1. Initialize Display
     // We set Mode 0 (Tilemap mode) which is common for 2D games,
     // and enable objects (sprites) to render them.
-    var display = hal.Display.init();
-    display.setMode0().setObject().setObject1D().writeRegister();
+    hal.display.setMode0();
+    hal.display.setObject();
+    hal.display.setObject1D();
+    hal.display.writeRegister();
 
     // 2. Setup Palette (PALRAM)
     // Object palette memory starts at 0x05000200.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ This layer acts as the GBA's **Hardware Driver Layer** (`zamgba.hal`). It handle
 ### Hardware Abstraction Layer (`zamgba.hal`)
 Maps GBA physical registers and exposes safe, atomic timing controls.
 *   **`hal.MemorySections`**: Direct pointers to physical segments like VRAM (`0x06000000`), PALRAM (`0x05000000`), and OAM (`0x07000000`).
-*   **`hal.Display`**: Configurations for GBA hardware register flags (Modes 0-5, Object enable, 1D/2D sprite mapping).
+*   **`hal.display`**: Configurations for GBA hardware register flags (Modes 0-5, Object enable, 1D/2D sprite mapping).
 *   **`hal.waitForVBlank()`**: Synchronizes the CPU game loop with the hardware display beam, blocking execution until the brief vertical blanking window starts.
 *   **`hal.oam.ObjAttr`**: A 64-bit packed struct defining the raw GBA hardware sprite attributes structure.
 *   **`hal.context.Mode3Context` / `Mode5Context`**: State-backed bitmap drawing contexts. They wrap VRAM physical addresses with automatic horizontal/vertical boundary checks and expose a standardized `drawPixel()` interface used by high-level drawing algorithms.

--- a/src/hal/display.zig
+++ b/src/hal/display.zig
@@ -5,46 +5,34 @@ const REG_IE = MemorySections.REG_IE;
 const REG_IF = MemorySections.REG_IF;
 const REG_IME = MemorySections.REG_IME;
 
-value: u16,
+pub var value: u16 = 0;
 
-pub fn init() @This() {
-    return @This(){
-        .value = 0,
-    };
+pub fn writeRegister() void {
+    (REG_DISPCNT.*) = value;
 }
 
-pub fn writeRegister(self: *@This()) void {
-    (REG_DISPCNT.*) = self.value;
-}
-
-pub fn loadRegister(self: *@This()) void {
-    self.value = (REG_DISPCNT.*);
+pub fn loadRegister() void {
+    value = (REG_DISPCNT.*);
 }
 
 // DCNT_MODE
-pub fn setMode0(self: *@This()) *@This() {
-    self.value |= 0x0000;
-    return self;
+pub fn setMode0() void {
+    value |= 0x0000;
 }
-pub fn setMode1(self: *@This()) *@This() {
-    self.value |= 0x0001;
-    return self;
+pub fn setMode1() void {
+    value |= 0x0001;
 }
-pub fn setMode2(self: *@This()) *@This() {
-    self.value |= 0x0002;
-    return self;
+pub fn setMode2() void {
+    value |= 0x0002;
 }
-pub fn setMode3(self: *@This()) *@This() {
-    self.value |= 0x0003;
-    return self;
+pub fn setMode3() void {
+    value |= 0x0003;
 }
-pub fn setMode4(self: *@This()) *@This() {
-    self.value |= 0x0004;
-    return self;
+pub fn setMode4() void {
+    value |= 0x0004;
 }
-pub fn setMode5(self: *@This()) *@This() {
-    self.value |= 0x0005;
-    return self;
+pub fn setMode5() void {
+    value |= 0x0005;
 }
 
 // DCNT_GB
@@ -53,13 +41,11 @@ pub fn isGBC() bool {
 }
 
 // DCNT_PAGE
-pub fn selectPage1(self: *@This()) *@This() {
-    self.value |= 0x0010;
-    return self;
+pub fn selectPage1() void {
+    value |= 0x0010;
 }
-pub fn selectPage0(self: *@This()) *@This() {
-    self.value &= 0xFFEF;
-    return self;
+pub fn selectPage0() void {
+    value &= 0xFFEF;
 }
 
 pub fn isPage0() bool {
@@ -109,67 +95,55 @@ pub fn flipPage() void {
 // DCNT_OM
 // DCNT_FB
 // DCNT_BG{0-3}
-pub fn setBackground0(self: *@This()) *@This() {
-    self.value |= 0x0100;
-    return self;
+pub fn setBackground0() void {
+    value |= 0x0100;
 }
 
-pub fn setBackground1(self: *@This()) *@This() {
-    self.value |= 0x0200;
-    return self;
+pub fn setBackground1() void {
+    value |= 0x0200;
 }
 
-pub fn setBackground2(self: *@This()) *@This() {
-    self.value |= 0x0400;
-    return self;
+pub fn setBackground2() void {
+    value |= 0x0400;
 }
 
-pub fn setBackground3(self: *@This()) *@This() {
-    self.value |= 0x0800;
-    return self;
+pub fn setBackground3() void {
+    value |= 0x0800;
 }
 
-pub fn unsetBackground0(self: *@This()) *@This() {
-    self.value &= 0xFEFF;
-    return self;
+pub fn unsetBackground0() void {
+    value &= 0xFEFF;
 }
 
-pub fn unsetBackground1(self: *@This()) *@This() {
-    self.value &= 0xFDFF;
-    return self;
+pub fn unsetBackground1() void {
+    value &= 0xFDFF;
 }
 
-pub fn unsetBackground2(self: *@This()) *@This() {
-    self.value &= 0xFBFF;
-    return self;
+pub fn unsetBackground2() void {
+    value &= 0xFBFF;
 }
 
-pub fn unsetBackground3(self: *@This()) *@This() {
-    self.value &= 0xF7FF;
-    return self;
+pub fn unsetBackground3() void {
+    value &= 0xF7FF;
 }
 
 pub const DCNT_OBJ: u16 = 0x1000;
 pub const DCNT_OBJ_1D: u16 = 0x0040;
 
-pub fn setObject(self: *@This()) *@This() {
-    self.value |= DCNT_OBJ;
-    return self;
+pub fn setObject() void {
+    value |= DCNT_OBJ;
 }
 
-pub fn unsetObject(self: *@This()) *@This() {
-    self.value &= ~DCNT_OBJ;
-    return self;
+pub fn unsetObject() void {
+    value &= ~DCNT_OBJ;
 }
 
-pub fn setObject1D(self: *@This()) *@This() {
-    self.value |= DCNT_OBJ_1D;
-    return self;
+pub fn setObject1D() void {
+    value |= DCNT_OBJ_1D;
 }
 
-pub fn unsetObject1D(self: *@This()) *@This() {
-    self.value &= ~DCNT_OBJ_1D;
-    return self;
+pub fn unsetObject1D() void {
+    value &= ~DCNT_OBJ_1D;
 }
 //
 // REG_DISPSTAT
@@ -179,13 +153,14 @@ pub fn unsetObject1D(self: *@This()) *@This() {
 // Unit tests
 // ===================================================================
 
-test "Display.SetModeAndBackground" {
+test "display.SetModeAndBackground" {
     const std = @import("std");
-    var disp = init();
+    value = 0;
 
     // Do not call .writeRegister() because it's only available when
     // running on a real GBA device. The address of REG_DISPCNT can
     // write to any result but what we want.
-    _ = disp.setMode3().setBackground2();
-    try std.testing.expect(disp.value == 0x0403);
+    setMode3();
+    setBackground2();
+    try std.testing.expect(value == 0x0403);
 }

--- a/src/hal/hal.zig
+++ b/src/hal/hal.zig
@@ -80,9 +80,9 @@ pub const Screen = struct {
     pub const MODE5_HEIGHT_PIXELS = 128;
 };
 
-pub const Display = @import("display.zig");
+pub const display = @import("display.zig");
 pub const joypad = @import("joypad.zig");
-pub const waitForVBlank = Display.waitForVBlank;
+pub const waitForVBlank = display.waitForVBlank;
 
 pub const oam = @import("oam.zig");
 pub const context = @import("context.zig");

--- a/src/unittest.zig
+++ b/src/unittest.zig
@@ -1,5 +1,5 @@
 comptime {
-    _ = @import("zamgba-hal").Display;
+    _ = @import("zamgba-hal").display;
     _ = @import("zamgba-engine").gfx2d;
     _ = @import("zamgba-engine").input;
     _ = @import("zamgba-engine").Color;


### PR DESCRIPTION
## Summary
- Removes  and instance requirement for , replacing it with a single  module representing the GBA's hardware display controller.
- Replaces struct instance state with a top-level  global variable inside .
- Updates  setter functions to return  and operate directly on the module state.
- Updates all demo ROMs (), unit tests (, ), and documentation (, ).

## Validation
-  (all demo ROMs build successfully)
-  (unit tests pass)