### PR TITLE
refactor(physics): migrate Fixed24_8 to signed representation and update Sprite velocity

### DIFF
--- a/demo/engine/collision_demo.zig
+++ b/demo/engine/collision_demo.zig
@@ -24,18 +24,18 @@ const Game = struct {
     map: CollisionMap,
     input: engine.input.InputState,
 
-    const PLAYER_START_X: u32 = 0;
-    const PLAYER_START_Y: u32 = 80;
+    const PLAYER_START_X: i32 = 0;
+    const PLAYER_START_Y: i32 = 80;
 
-    const ENEMY_1_START_X: u32 = 80;  // 1/3 of screen width (240 / 3)
-    const ENEMY_1_START_Y: u32 = 8;
-    const ENEMY_1_SPEED_Y: i32 = (1 << 8) + 128; // 1.5 pixels/frame
+    const ENEMY_1_START_X: i32 = 80; // 1/3 of screen width (240 / 3)
+    const ENEMY_1_START_Y: i32 = 8;
+    const ENEMY_1_SPEED_Y = Fixed24_8.fromFloat(1.5); // 1.5 pixels/frame
 
-    const ENEMY_2_START_X: u32 = 160; // 2/3 of screen width (240 * 2 / 3)
-    const ENEMY_2_START_Y: u32 = 144;
-    const ENEMY_2_SPEED_Y: i32 = -((1 << 8) + 128); // -1.5 pixels/frame
+    const ENEMY_2_START_X: i32 = 160; // 2/3 of screen width (240 * 2 / 3)
+    const ENEMY_2_START_Y: i32 = 144;
+    const ENEMY_2_SPEED_Y = Fixed24_8.fromFloat(-1.5); // -1.5 pixels/frame
 
-    const PLAYER_SPEED: i32 = 2 << 8; // 2.0 pixels/frame
+    const PLAYER_SPEED = Fixed24_8.fromInt(2); // 2.0 pixels/frame
 
     pub fn init() Game {
         var self = Game{
@@ -50,10 +50,10 @@ const Game = struct {
 
         // Configure 16-bit collision layers
         self.player.layer = Collision.layer(0); // Layer 0: Player
-        self.player.mask = Collision.layer(1);  // Mask: Enemy
+        self.player.mask = Collision.layer(1); // Mask: Enemy
 
         self.enemies[0].layer = Collision.layer(1); // Layer 1: Enemy
-        self.enemies[0].mask = Collision.layer(0);  // Mask: Player
+        self.enemies[0].mask = Collision.layer(0); // Mask: Player
         self.enemies[0].velocity_y = ENEMY_1_SPEED_Y;
 
         self.enemies[1].layer = Collision.layer(1);
@@ -78,8 +78,8 @@ const Game = struct {
     pub fn reset(self: *@This()) void {
         self.player.aabb.x = Fixed24_8.fromInt(PLAYER_START_X);
         self.player.aabb.y = Fixed24_8.fromInt(PLAYER_START_Y);
-        self.player.velocity_x = 0;
-        self.player.velocity_y = 0;
+        self.player.velocity_x = Fixed24_8.zero;
+        self.player.velocity_y = Fixed24_8.zero;
 
         self.enemies[0].aabb.x = Fixed24_8.fromInt(ENEMY_1_START_X);
         self.enemies[0].aabb.y = Fixed24_8.fromInt(ENEMY_1_START_Y);
@@ -94,13 +94,13 @@ const Game = struct {
         self.input.update();
 
         // 1. Process player input velocity
-        var vx: i32 = 0;
-        var vy: i32 = 0;
+        var vx = Fixed24_8.zero;
+        var vy = Fixed24_8.zero;
 
-        if (self.input.isPressed(.Left)) vx -= PLAYER_SPEED;
-        if (self.input.isPressed(.Right)) vx += PLAYER_SPEED;
-        if (self.input.isPressed(.Up)) vy -= PLAYER_SPEED;
-        if (self.input.isPressed(.Down)) vy += PLAYER_SPEED;
+        if (self.input.isPressed(.Left)) vx = vx.sub(PLAYER_SPEED);
+        if (self.input.isPressed(.Right)) vx = vx.add(PLAYER_SPEED);
+        if (self.input.isPressed(.Up)) vy = vy.sub(PLAYER_SPEED);
+        if (self.input.isPressed(.Down)) vy = vy.add(PLAYER_SPEED);
 
         self.player.velocity_x = vx;
         self.player.velocity_y = vy;
@@ -114,7 +114,7 @@ const Game = struct {
             const res = enemy.moveAndCollide(self.map);
             if (res.collided_y) {
                 // Reverse direction on map wall collision
-                enemy.velocity_y = -initial_vy;
+                enemy.velocity_y = initial_vy.neg();
             }
         }
 

--- a/demo/engine/flappy_tsetseg.zig
+++ b/demo/engine/flappy_tsetseg.zig
@@ -29,18 +29,20 @@ const Game = struct {
     anim_frame: u16 = 0,
     anim_timer: u16 = 0,
 
-    const PLAYER_START_X: u32 = 8;
-    const PLAYER_START_Y: u32 = 64;
+    const PLAYER_START_X: i32 = 8;
+    const PLAYER_START_Y: i32 = 64;
 
-    const ENEMY_1_START_X: u32 = 90;
-    const ENEMY_1_START_Y: u32 = 8;
-    const ENEMY_1_SPEED_Y: i32 = (1 << 8) + 64; // ~1.25 pixels/frame
+    const ENEMY_1_START_X: i32 = 90;
+    const ENEMY_1_START_Y: i32 = 8;
+    // 1.25 pixels/frame vertical patrol velocity
+    const ENEMY_1_SPEED_Y = Fixed24_8.fromFloat(1.25);
 
-    const ENEMY_2_START_X: u32 = 170;
-    const ENEMY_2_START_Y: u32 = 120;
-    const ENEMY_2_SPEED_Y: i32 = -((1 << 8) + 64);
+    const ENEMY_2_START_X: i32 = 170;
+    const ENEMY_2_START_Y: i32 = 120;
+    const ENEMY_2_SPEED_Y = Fixed24_8.fromFloat(-1.25);
 
-    const PLAYER_SPEED: i32 = 2 << 8; // 2.0 pixels/frame
+    // 2.0 pixels/frame horizontal & vertical movement speed
+    const PLAYER_SPEED = Fixed24_8.fromInt(2);
     const FRAME_DURATION_TICKS: u16 = 6; // 6 frames at 60Hz ~= 100ms per animation frame
 
     // In GBA 1D 8-bpp mapping, a 32x32 sprite (1024 bytes) advances by 32 tile index units per frame
@@ -104,8 +106,8 @@ const Game = struct {
     pub fn reset(self: *@This()) void {
         self.player.aabb.x = Fixed24_8.fromInt(PLAYER_START_X);
         self.player.aabb.y = Fixed24_8.fromInt(PLAYER_START_Y);
-        self.player.velocity_x = 0;
-        self.player.velocity_y = 0;
+        self.player.velocity_x = Fixed24_8.zero;
+        self.player.velocity_y = Fixed24_8.zero;
         self.player.h_flip = false;
         self.anim_frame = 0;
         self.anim_timer = 0;
@@ -123,19 +125,19 @@ const Game = struct {
         self.input.update();
 
         // 1. Process player directional input & horizontal flipping
-        var vx: i32 = 0;
-        var vy: i32 = 0;
+        var vx = Fixed24_8.zero;
+        var vy = Fixed24_8.zero;
 
         if (self.input.isPressed(.Left)) {
-            vx -= PLAYER_SPEED;
+            vx = vx.sub(PLAYER_SPEED);
             self.player.h_flip = true; // Face left
         }
         if (self.input.isPressed(.Right)) {
-            vx += PLAYER_SPEED;
+            vx = vx.add(PLAYER_SPEED);
             self.player.h_flip = false; // Face right
         }
-        if (self.input.isPressed(.Up)) vy -= PLAYER_SPEED;
-        if (self.input.isPressed(.Down)) vy += PLAYER_SPEED;
+        if (self.input.isPressed(.Up)) vy = vy.sub(PLAYER_SPEED);
+        if (self.input.isPressed(.Down)) vy = vy.add(PLAYER_SPEED);
 
         self.player.velocity_x = vx;
         self.player.velocity_y = vy;
@@ -148,7 +150,7 @@ const Game = struct {
             const initial_vy = enemy.velocity_y;
             const res = enemy.moveAndCollide(self.map);
             if (res.collided_y) {
-                enemy.velocity_y = -initial_vy;
+                enemy.velocity_y = initial_vy.neg();
             }
         }
 

--- a/demo/engine/pong.zig
+++ b/demo/engine/pong.zig
@@ -22,9 +22,9 @@ const SCREEN_H: i32 = 160;
 const PLAYER_X: u32 = 12;
 const AI_X: u32 = 240 - 12 - PADDLE_W; // 220
 
-const PADDLE_SPEED: i32 = 2 << 8; // 2.0 pixels/frame
-const BALL_SPEED_X: i32 = (2 << 8) + 64; // 2.25 pixels/frame
-const BALL_SPEED_Y: i32 = (1 << 8) + 128; // 1.5 pixels/frame
+const PADDLE_SPEED = Fixed24_8.fromInt(2); // 2.0 pixels/frame
+const BALL_SPEED_X = Fixed24_8.fromFloat(2.25); // 2.25 pixels/frame
+const BALL_SPEED_Y = Fixed24_8.fromFloat(1.5); // 1.5 pixels/frame
 
 const Game = struct {
     player: engine.Sprite,
@@ -42,12 +42,12 @@ const Game = struct {
 
         // 16-bit collision layer assignments
         self.player.layer = Collision.layer(0); // Player layer
-        self.player.mask = Collision.layer(2);  // Interacts with Ball
+        self.player.mask = Collision.layer(2); // Interacts with Ball
 
-        self.ai.layer = Collision.layer(1);     // AI layer
-        self.ai.mask = Collision.layer(2);      // Interacts with Ball
+        self.ai.layer = Collision.layer(1); // AI layer
+        self.ai.mask = Collision.layer(2); // Interacts with Ball
 
-        self.ball.layer = Collision.layer(2);   // Ball layer
+        self.ball.layer = Collision.layer(2); // Ball layer
         self.ball.mask = Collision.layer(0) | Collision.layer(1);
 
         // Ball initial velocity
@@ -74,9 +74,9 @@ const Game = struct {
     }
 
     pub fn resetBall(self: *@This(), serve_right: bool) void {
-        self.ball.aabb.x = Fixed24_8.fromInt(@intCast((SCREEN_W - BALL_SIZE) / 2));
-        self.ball.aabb.y = Fixed24_8.fromInt(@intCast((SCREEN_H - BALL_SIZE) / 2));
-        self.ball.velocity_x = if (serve_right) BALL_SPEED_X else -BALL_SPEED_X;
+        self.ball.aabb.x = Fixed24_8.fromInt((SCREEN_W - BALL_SIZE) / 2);
+        self.ball.aabb.y = Fixed24_8.fromInt((SCREEN_H - BALL_SIZE) / 2);
+        self.ball.velocity_x = if (serve_right) BALL_SPEED_X else BALL_SPEED_X.neg();
         self.ball.velocity_y = BALL_SPEED_Y;
     }
 
@@ -84,56 +84,53 @@ const Game = struct {
         self.input.update();
 
         // 1. Player paddle control (D-Pad Up / Down)
-        var player_vy: i32 = 0;
-        if (self.input.isPressed(.Up)) player_vy -= PADDLE_SPEED;
-        if (self.input.isPressed(.Down)) player_vy += PADDLE_SPEED;
+        var player_vy = Fixed24_8.zero;
+        if (self.input.isPressed(.Up)) player_vy = player_vy.sub(PADDLE_SPEED);
+        if (self.input.isPressed(.Down)) player_vy = player_vy.add(PADDLE_SPEED);
 
-        const cur_player_y: i32 = @intCast(self.player.aabb.y.toInt());
-        const next_player_y = std.math.clamp(cur_player_y + (player_vy >> 8), 0, SCREEN_H - PADDLE_H);
-        self.player.aabb.y = Fixed24_8.fromInt(@intCast(next_player_y));
+        const cur_player_y = self.player.aabb.y.toInt();
+        const next_player_y = std.math.clamp(cur_player_y + player_vy.toInt(), 0, SCREEN_H - PADDLE_H);
+        self.player.aabb.y = Fixed24_8.fromInt(next_player_y);
 
         // 2. AI paddle tracking logic
-        const ball_center_y: i32 = @intCast(self.ball.aabb.y.toInt() + BALL_SIZE / 2);
-        const ai_center_y: i32 = @intCast(self.ai.aabb.y.toInt() + PADDLE_H / 2);
-        var ai_vy: i32 = 0;
+        const ball_center_y = self.ball.aabb.y.toInt() + BALL_SIZE / 2;
+        const ai_center_y = self.ai.aabb.y.toInt() + PADDLE_H / 2;
+        var ai_vy = Fixed24_8.zero;
         if (ai_center_y < ball_center_y - 2) {
-            ai_vy = PADDLE_SPEED - 64; // Slightly slower for balanced gameplay
+            ai_vy = PADDLE_SPEED.sub(Fixed24_8.fromFloat(0.25)); // Slightly slower for balanced gameplay
         } else if (ai_center_y > ball_center_y + 2) {
-            ai_vy = -(PADDLE_SPEED - 64);
+            ai_vy = PADDLE_SPEED.sub(Fixed24_8.fromFloat(0.25)).neg();
         }
 
-        const cur_ai_y: i32 = @intCast(self.ai.aabb.y.toInt());
-        const next_ai_y = std.math.clamp(cur_ai_y + (ai_vy >> 8), 0, SCREEN_H - PADDLE_H);
-        self.ai.aabb.y = Fixed24_8.fromInt(@intCast(next_ai_y));
+        const cur_ai_y = self.ai.aabb.y.toInt();
+        const next_ai_y = std.math.clamp(cur_ai_y + ai_vy.toInt(), 0, SCREEN_H - PADDLE_H);
+        self.ai.aabb.y = Fixed24_8.fromInt(next_ai_y);
 
         // 3. Move Ball with sub-pixel precision
-        const next_ball_raw_x = @as(i64, self.ball.aabb.x.raw) + self.ball.velocity_x;
-        const next_ball_raw_y = @as(i64, self.ball.aabb.y.raw) + self.ball.velocity_y;
+        self.ball.aabb.x = self.ball.aabb.x.add(self.ball.velocity_x);
+        self.ball.aabb.y = self.ball.aabb.y.add(self.ball.velocity_y);
 
-        self.ball.aabb.x.raw = @intCast(@max(0, next_ball_raw_x));
-        self.ball.aabb.y.raw = @intCast(@max(0, next_ball_raw_y));
-
-        const cur_ball_x_px: i32 = @intCast(self.ball.aabb.x.toInt());
-        const cur_ball_y_px: i32 = @intCast(self.ball.aabb.y.toInt());
+        const cur_ball_x_px = self.ball.aabb.x.toInt();
+        const cur_ball_y_px = self.ball.aabb.y.toInt();
 
         // 4. Ball bounce on top and bottom screen boundaries
         if (cur_ball_y_px <= 0) {
             self.ball.aabb.y = Fixed24_8.fromInt(0);
-            self.ball.velocity_y = @intCast(@abs(self.ball.velocity_y));
+            self.ball.velocity_y = Fixed24_8{ .raw = @intCast(@abs(self.ball.velocity_y.raw)) };
         } else if (cur_ball_y_px >= SCREEN_H - BALL_SIZE) {
-            self.ball.aabb.y = Fixed24_8.fromInt(@intCast(SCREEN_H - BALL_SIZE));
-            self.ball.velocity_y = -@as(i32, @intCast(@abs(self.ball.velocity_y)));
+            self.ball.aabb.y = Fixed24_8.fromInt(SCREEN_H - BALL_SIZE);
+            self.ball.velocity_y = Fixed24_8{ .raw = -@as(i32, @intCast(@abs(self.ball.velocity_y.raw))) };
         }
 
         // 5. Paddle vs Ball AABB collision
         if (self.player.aabb.isColliding(self.ball.aabb)) {
             // Ball hits Player paddle -> bounce right
             self.ball.aabb.x = Fixed24_8.fromInt(PLAYER_X + PADDLE_W);
-            self.ball.velocity_x = @intCast(@abs(self.ball.velocity_x));
+            self.ball.velocity_x = Fixed24_8{ .raw = @intCast(@abs(self.ball.velocity_x.raw)) };
         } else if (self.ai.aabb.isColliding(self.ball.aabb)) {
             // Ball hits AI paddle -> bounce left
             self.ball.aabb.x = Fixed24_8.fromInt(AI_X - BALL_SIZE);
-            self.ball.velocity_x = -@as(i32, @intCast(@abs(self.ball.velocity_x)));
+            self.ball.velocity_x = Fixed24_8{ .raw = -@as(i32, @intCast(@abs(self.ball.velocity_x.raw))) };
         }
 
         // 6. Goal scoring and ball reset

--- a/docs/fixed_number.md
+++ b/docs/fixed_number.md
@@ -9,15 +9,15 @@ This document explains the design principles, performance considerations, and us
 GBA uses an **ARM7TDMI** processor without a Floating-Point Unit (FPU). Any standard 32-bit floating-point operation (`f32`) incurs heavy software emulation (`__aeabi_fadd`, `__aeabi_fmul`, etc.) costing tens to hundreds of CPU cycles per calculation.
 
 To achieve high-performance physics and collision detection, Zamgba uses a fixed-point representation:
-- **Underlying Type**: `u32` (32 bits unsigned integer).
+- **Underlying Type**: `i32` (32-bit signed two's complement integer).
 - **Format**: `Fixed24_8`
-  - High 24 bits (Bits 8–31): Integer part.
+  - High 24 bits (Bits 8–31): Signed integer part (range: $-8,388,608$ to $+8,388,607$).
   - Low 8 bits (Bits 0–7): Fractional part ($1 / 256 \approx 0.00390625$ resolution).
 
 ```
  31                          8 7         0
 +-----------------------------+-----------+
-|        Integer (24 bits)    | Frac (8b) |
+|    Signed Integer (24 bits) | Frac (8b) |
 +-----------------------------+-----------+
 ```
 
@@ -33,16 +33,16 @@ Zig provides the `comptime` parameter qualifier. By constraining the constructor
 
 ```zig
 pub fn fromFloat(comptime f: comptime_float) Fixed24_8 {
-    return .{ .raw = @as(u32, @intFromFloat(f * @as(comptime_float, scale))) };
+    return .{ .raw = @as(i32, @intFromFloat(f * @as(comptime_float, scale))) };
 }
 ```
 
-#### Detailed Breakdown of `@as(u32, @intFromFloat(f * @as(comptime_float, scale)))`
+#### Detailed Breakdown of `@as(i32, @intFromFloat(f * @as(comptime_float, scale)))`
 1. `scale` is defined as `1 << 8` (`256`).
 2. `@as(comptime_float, scale)` coerces the integer `256` into a compile-time float `256.0` to satisfy Zig's strict type-matching for floating-point arithmetic.
-3. `f * 256.0` scales the float value into fixed-point representation (e.g., `3.5 * 256.0 = 896.0`).
-4. `@intFromFloat(...)` converts the compile-time float `896.0` to an integer `896`.
-5. `@as(u32, ...)` coerces the compile-time integer literal `896` into a standard `u32` for storing in `.raw`.
+3. `f * 256.0` scales the float value into fixed-point representation (e.g., `3.5 * 256.0 = 896.0` or `-1.5 * 256.0 = -384.0`).
+4. `@intFromFloat(...)` converts the compile-time float to a signed integer.
+5. `@as(i32, ...)` coerces the compile-time integer literal into an `i32` for storing in `.raw`.
 6. Because all inputs are `comptime`, LLVM folds this entire expression into a single immediate constant (e.g. `896` / `0x380`) during compilation, resulting in **zero** runtime instructions.
 
 ---
@@ -95,16 +95,18 @@ $$\text{fraction} = \text{round}(0.x \times 256)$$
 
 For runtime values where fractions or parts are computed from integers:
 
-- **`fromParts(integer: u32, fraction: u8)`**: Directly combines an integer and an 8-bit fraction counter (`(integer << 8) | fraction`).
-- **`fromFraction(integer: u32, num: u32, den: u32)`**: Constructs value from rational numbers (e.g. `fromFraction(3, 1, 2)` for $3 + \frac{1}{2}$).
-- **`fromInt(i: u32)`**: Simple whole integer constructor (`i << 8`).
+- **`fromParts(integer: i32, fraction: u8)`**: Combines an integer and an 8-bit fraction counter with proper sign handling.
+- **`fromFraction(integer: i32, num: i32, den: i32)`**: Constructs value from rational numbers (e.g. `fromFraction(3, 1, 2)` for $3 + \frac{1}{2}$, using `@divTrunc`).
+- **`fromInt(i: i32)`**: Simple whole integer constructor (`i << 8`).
+- **`Fixed24_8.zero`**: Constant for $0.0$.
+- **`neg()`**: Negates a value (`-self.raw`).
 
 ---
 
 ## 5. Assignment, Passing, and Memory Semantics
 
 ### Direct Assignment (`=`)
-Because `Fixed24_8` wraps a single 32-bit field (`raw: u32`), instances can and should be copied using standard assignment:
+Because `Fixed24_8` wraps a single 32-bit field (`raw: i32`), instances can and should be copied using standard assignment:
 
 ```zig
 var a = Fixed24_8.fromFloat(3.5);
@@ -126,3 +128,28 @@ var b: Fixed24_8 = a; // Direct copy
    ```zig
    @memcpy(dest_slice, src_slice);
    ```
+
+---
+
+## 6. From Unsigned to Signed: Design Decisions & Screen Impact
+
+In earlier versions of Zamgba, `Fixed24_8` was represented as an unsigned integer (`raw: u32`). Moving to a fully signed `raw: i32` representation resolved fundamental architectural trade-offs:
+
+### 1. Unified Velocity & Position Model
+- **Problem**: Velocity components (`velocity_x`, `velocity_y`) are inherently signed vectors (e.g., `-1.5` pixels/frame when moving left or up). With unsigned `Fixed24_8`, velocity had to be kept as raw `i32` with manual bit shifts (`vx >> 8`), creating semantic duplication and risk of mixing raw pixel integers with fixed-point integers.
+- **Solution**: `Sprite.velocity_x` and `velocity_y` are now typed as `Fixed24_8`. Both positions and velocities use identical arithmetic methods (`.add()`, `.sub()`, `.mul()`, `.div()`, `.neg()`), catching unit mismatches at compile time.
+
+### 2. Direction Flipping & Wall Bouncing
+- Inverting movement direction on wall collisions or input flips now executes via `.neg()` (`enemy.velocity_y = enemy.velocity_y.neg()`).
+- On ARM7TDMI, negating a 32-bit signed register is a single-cycle instruction (`rsb r0, r0, #0` or `neg`), avoiding branching and absolute value conversions.
+
+### 3. Screen Coordinate & OAM Hardware Mapping
+Converting `Fixed24_8` to integer screen coordinates (`toInt()`) uses arithmetic right shift (`raw >> 8` / `ASR` on ARM):
+- **Positive Coordinates (On-screen)**: `toInt()` maps directly to the integer pixel grid with sub-pixel truncation.
+- **Negative Coordinates (Entering/Exiting Screen)**: Two's complement arithmetic right shift computes floor division (`floor(x)`), mapping $[-0.5, 0.0)$ consistently to $-1\text{px}$.
+- **GBA OAM Register Alignment**:
+  ```zig
+  const y_hw: u16 = @as(u16, @bitCast(@as(i16, @truncate(y_val)))) & 0x00FF; // 8-bit wrap (0..255)
+  const x_hw: u16 = @as(u16, @bitCast(@as(i16, @truncate(x_val)))) & 0x01FF; // 9-bit wrap (0..511)
+  ```
+  The GBA OBJ hardware wraps negative coordinates smoothly around screen boundaries (e.g. $X = -8 \implies 504$ in 9-bit coordinates). Floor rounding ensures continuous, jitter-free sprite entry from the left and top screen borders.

--- a/src/engine/physics/aabb.zig
+++ b/src/engine/physics/aabb.zig
@@ -21,7 +21,7 @@ pub const AABB = struct {
     }
 
     /// Create an AABB with integer coordinates.
-    pub fn fromInt(x: u32, y: u32, width: u16, height: u16) AABB {
+    pub fn fromInt(x: i32, y: i32, width: u16, height: u16) AABB {
         return .{
             .x = Fixed24_8.fromInt(x),
             .y = Fixed24_8.fromInt(y),
@@ -32,12 +32,12 @@ pub const AABB = struct {
 
     /// Returns the right boundary (x + width) in Fixed24_8.
     pub fn right(self: AABB) Fixed24_8 {
-        return .{ .raw = self.x.raw + (@as(u32, self.width) << Fixed24_8.fraction_bits) };
+        return .{ .raw = self.x.raw + (@as(i32, @intCast(self.width)) << Fixed24_8.fraction_bits) };
     }
 
     /// Returns the bottom boundary (y + height) in Fixed24_8.
     pub fn bottom(self: AABB) Fixed24_8 {
-        return .{ .raw = self.y.raw + (@as(u32, self.height) << Fixed24_8.fraction_bits) };
+        return .{ .raw = self.y.raw + (@as(i32, @intCast(self.height)) << Fixed24_8.fraction_bits) };
     }
 
     /// Check if this AABB collides with another AABB.
@@ -69,28 +69,28 @@ pub const AABB = struct {
     }
 };
 
-test "AABB isColliding basic overlap" {
+test "ABB001: AABB isColliding basic overlap" {
     const box1 = AABB.fromInt(10, 10, 20, 20); // [10, 30) x [10, 30)
     const box2 = AABB.fromInt(20, 20, 20, 20); // [20, 40) x [20, 40)
     try std.testing.expect(box1.isColliding(box2));
     try std.testing.expect(box2.collidesWith(box1));
 }
 
-test "AABB isColliding separated" {
+test "ABB002: AABB isColliding separated" {
     const box1 = AABB.fromInt(0, 0, 10, 10);
     const box2 = AABB.fromInt(20, 20, 10, 10);
     try std.testing.expect(!box1.isColliding(box2));
     try std.testing.expect(!box2.collidesWith(box1));
 }
 
-test "AABB isColliding touching boundary does not collide" {
+test "ABB003: AABB isColliding touching boundary does not collide" {
     const box1 = AABB.fromInt(0, 0, 10, 10); // [0, 10) x [0, 10)
     const box2 = AABB.fromInt(10, 0, 10, 10); // [10, 20) x [0, 10)
     try std.testing.expect(!box1.isColliding(box2));
     try std.testing.expect(!box2.collidesWith(box1));
 }
 
-test "AABB sub-pixel collision" {
+test "ABB004: AABB sub-pixel collision" {
     // box1: [0, 10) x [0, 10)
     const box1 = AABB.fromInt(0, 0, 10, 10);
     // box2: [9.5, 19.5) x [0, 10) -> overlaps by 0.5 pixels
@@ -102,7 +102,7 @@ test "AABB sub-pixel collision" {
     try std.testing.expect(!box1.isColliding(box3));
 }
 
-test "AABB containsPoint" {
+test "ABB005: AABB containsPoint" {
     const box = AABB.fromInt(10, 10, 20, 20); // [10, 30) x [10, 30)
 
     try std.testing.expect(box.containsPoint(Fixed24_8.fromInt(10), Fixed24_8.fromInt(10)));

--- a/src/engine/physics/math.zig
+++ b/src/engine/physics/math.zig
@@ -1,38 +1,49 @@
 const std = @import("std");
 
-/// 24.8 fixed-point number based on u32.
-/// High 24 bits for the integer part, low 8 bits for the fractional part.
+/// Signed 24.8 fixed-point number based on i32.
+/// High 24 bits for the signed integer part, low 8 bits for the fractional part.
 pub const Fixed24_8 = struct {
-    raw: u32,
+    raw: i32,
+
+    pub const zero = Fixed24_8{ .raw = 0 };
 
     pub const fraction_bits = 8;
-    pub const scale = 1 << fraction_bits;
+    pub const scale: i32 = 1 << fraction_bits;
 
-    /// Create a Fixed24_8 from an integer.
-    pub fn fromInt(i: u32) Fixed24_8 {
+    /// Create a Fixed24_8 from a signed integer.
+    pub fn fromInt(i: i32) Fixed24_8 {
         return .{ .raw = i << fraction_bits };
     }
 
     /// Create a Fixed24_8 from a comptime-known float literal.
     /// Evaluated purely at compile-time with zero runtime floating-point overhead.
     pub fn fromFloat(comptime f: comptime_float) Fixed24_8 {
-        return .{ .raw = @as(u32, @intFromFloat(f * @as(comptime_float, scale))) };
+        return .{ .raw = @as(i32, @intFromFloat(f * @as(comptime_float, scale))) };
     }
 
     /// Create a Fixed24_8 from an integer part and an 8-bit fraction (0-255).
-    pub fn fromParts(integer: u32, fraction: u8) Fixed24_8 {
-        return .{ .raw = (integer << fraction_bits) | fraction };
+    pub fn fromParts(integer: i32, fraction: u8) Fixed24_8 {
+        if (integer < 0) {
+            return .{ .raw = (integer << fraction_bits) - @as(i32, fraction) };
+        } else {
+            return .{ .raw = (integer << fraction_bits) + @as(i32, fraction) };
+        }
     }
 
     /// Create a Fixed24_8 from an integer and a fraction (numerator / denominator).
-    pub fn fromFraction(integer: u32, numerator: u32, denominator: u32) Fixed24_8 {
-        const frac = (numerator * scale) / denominator;
+    pub fn fromFraction(integer: i32, numerator: i32, denominator: i32) Fixed24_8 {
+        const frac = @divTrunc((numerator * scale), denominator);
         return .{ .raw = (integer << fraction_bits) + frac };
     }
 
-    /// Convert back to an integer (truncates the fractional part).
-    pub fn toInt(self: Fixed24_8) u32 {
+    /// Convert back to an integer (arithmetic right shift preserves sign).
+    pub fn toInt(self: Fixed24_8) i32 {
         return self.raw >> fraction_bits;
+    }
+
+    /// Negate a fixed-point number.
+    pub fn neg(self: Fixed24_8) Fixed24_8 {
+        return .{ .raw = -self.raw };
     }
 
     /// Add two fixed-point numbers.
@@ -47,85 +58,92 @@ pub const Fixed24_8 = struct {
 
     /// Multiply two fixed-point numbers.
     pub fn mul(self: Fixed24_8, other: Fixed24_8) Fixed24_8 {
-        // Use u64 to prevent overflow during multiplication
-        const result_64 = @as(u64, self.raw) * @as(u64, other.raw);
-        return .{ .raw = @as(u32, @intCast(result_64 >> fraction_bits)) };
+        const result_64 = @as(i64, self.raw) * @as(i64, other.raw);
+        return .{ .raw = @as(i32, @intCast(result_64 >> fraction_bits)) };
     }
 
     /// Divide two fixed-point numbers.
     pub fn div(self: Fixed24_8, other: Fixed24_8) Fixed24_8 {
-        const dividend_64 = @as(u64, self.raw) << fraction_bits;
-        return .{ .raw = @as(u32, @intCast(dividend_64 / other.raw)) };
+        const dividend_64 = @as(i64, self.raw) << fraction_bits;
+        return .{ .raw = @as(i32, @intCast(@divTrunc(dividend_64, other.raw))) };
     }
 };
 
-test "Fixed24_8 fromInt and toInt" {
+test "MAT001: Fixed24_8 fromInt and toInt (positive and negative)" {
     const a = Fixed24_8.fromInt(5);
-    try std.testing.expectEqual(@as(u32, 5 << 8), a.raw);
-    try std.testing.expectEqual(@as(u32, 5), a.toInt());
+    try std.testing.expectEqual(@as(i32, 5 << 8), a.raw);
+    try std.testing.expectEqual(@as(i32, 5), a.toInt());
+
+    const neg_a = Fixed24_8.fromInt(-5);
+    try std.testing.expectEqual(@as(i32, -5 << 8), neg_a.raw);
+    try std.testing.expectEqual(@as(i32, -5), neg_a.toInt());
 }
 
-test "Fixed24_8 fromFloat" {
+test "MAT002: Fixed24_8 fromFloat" {
     const a = Fixed24_8.fromFloat(3.5);
-    try std.testing.expectEqual(@as(u32, (3 << 8) + 128), a.raw);
-    try std.testing.expectEqual(@as(u32, 3), a.toInt());
+    try std.testing.expectEqual(@as(i32, (3 << 8) + 128), a.raw);
+    try std.testing.expectEqual(@as(i32, 3), a.toInt());
+
+    const neg_f = Fixed24_8.fromFloat(-2.5);
+    try std.testing.expectEqual(@as(i32, (-2 << 8) - 128), neg_f.raw);
+    try std.testing.expectEqual(@as(i32, -3), neg_f.toInt());
 
     const b = Fixed24_8.fromFloat(0.125); // 1/8 -> 32/256
-    try std.testing.expectEqual(@as(u32, 32), b.raw);
+    try std.testing.expectEqual(@as(i32, 32), b.raw);
 }
 
-test "Fixed24_8 fromParts" {
+test "MAT003: Fixed24_8 fromParts" {
     const a = Fixed24_8.fromParts(3, 128);
-    try std.testing.expectEqual(@as(u32, (3 << 8) + 128), a.raw);
-    try std.testing.expectEqual(@as(u32, 3), a.toInt());
+    try std.testing.expectEqual(@as(i32, (3 << 8) + 128), a.raw);
+    try std.testing.expectEqual(@as(i32, 3), a.toInt());
 }
 
-test "Fixed24_8 fromFraction" {
+test "MAT004: Fixed24_8 fromFraction" {
     const a = Fixed24_8.fromFraction(3, 1, 2); // 3 + 1/2 -> 3.5
-    try std.testing.expectEqual(@as(u32, (3 << 8) + 128), a.raw);
+    try std.testing.expectEqual(@as(i32, (3 << 8) + 128), a.raw);
 
     const b = Fixed24_8.fromFraction(0, 1, 4); // 0 + 1/4 -> 64/256
-    try std.testing.expectEqual(@as(u32, 64), b.raw);
+    try std.testing.expectEqual(@as(i32, 64), b.raw);
 }
 
-test "Fixed24_8 add" {
+test "MAT005: Fixed24_8 add and sub" {
     const a = Fixed24_8.fromInt(5);
     const b = Fixed24_8.fromInt(3);
     const c = a.add(b);
-    try std.testing.expectEqual(@as(u32, 8), c.toInt());
+    try std.testing.expectEqual(@as(i32, 8), c.toInt());
+
+    const d = a.sub(b);
+    try std.testing.expectEqual(@as(i32, 2), d.toInt());
 
     // Test with fractional parts
     const x = Fixed24_8.fromFloat(2.5);
     const y = Fixed24_8.fromFloat(1.5);
     const z = x.add(y);
-    try std.testing.expectEqual(@as(u32, 4 << 8), z.raw); // 4.0
+    try std.testing.expectEqual(@as(i32, 4 << 8), z.raw); // 4.0
 }
 
-test "Fixed24_8 sub" {
-    const a = Fixed24_8.fromInt(5);
-    const b = Fixed24_8.fromInt(3);
-    const c = a.sub(b);
-    try std.testing.expectEqual(@as(u32, 2), c.toInt());
-}
-
-test "Fixed24_8 mul" {
+test "MAT006: Fixed24_8 mul" {
     const a = Fixed24_8.fromInt(5);
     const b = Fixed24_8.fromInt(3);
     const c = a.mul(b);
-    try std.testing.expectEqual(@as(u32, 15), c.toInt());
+    try std.testing.expectEqual(@as(i32, 15), c.toInt());
 
     // 1.5 * 2 = 3
     const x = Fixed24_8.fromFloat(1.5);
     const y = Fixed24_8.fromInt(2);
     const z = x.mul(y);
-    try std.testing.expectEqual(@as(u32, 3 << 8), z.raw);
+    try std.testing.expectEqual(@as(i32, 3 << 8), z.raw);
+
+    // Negative multiplication
+    const neg_res = x.mul(Fixed24_8.fromInt(-2));
+    try std.testing.expectEqual(@as(i32, -3 << 8), neg_res.raw);
 }
 
-test "Fixed24_8 div" {
+test "MAT007: Fixed24_8 div" {
     const a = Fixed24_8.fromInt(15);
     const b = Fixed24_8.fromInt(3);
     const c = a.div(b);
-    try std.testing.expectEqual(@as(u32, 5), c.toInt());
+    try std.testing.expectEqual(@as(i32, 5), c.toInt());
 
     // 5 / 2 = 2.5
     const x = Fixed24_8.fromInt(5);
@@ -134,42 +152,49 @@ test "Fixed24_8 div" {
     try std.testing.expectEqual(Fixed24_8.fromFloat(2.5).raw, z.raw);
 }
 
-test "Fixed24_8 quick reference table conformity" {
+test "MAT008: Fixed24_8 neg" {
+    const a = Fixed24_8.fromFloat(2.5);
+    const b = a.neg();
+    try std.testing.expectEqual(Fixed24_8.fromFloat(-2.5).raw, b.raw);
+    try std.testing.expectEqual(a.raw, b.neg().raw);
+}
+
+test "MAT009: Fixed24_8 quick reference table conformity" {
     // 3.5 -> (3 << 8) + 128
     const val_3_5 = Fixed24_8.fromFloat(3.5);
-    try std.testing.expectEqual(@as(u32, (3 << 8) + 128), val_3_5.raw);
+    try std.testing.expectEqual(@as(i32, (3 << 8) + 128), val_3_5.raw);
 
     // 0.5 -> 128 (0x80)
-    try std.testing.expectEqual(@as(u32, 128), Fixed24_8.fromFloat(0.5).raw);
-    try std.testing.expectEqual(@as(u32, 128), Fixed24_8.fromFraction(0, 1, 2).raw);
-    try std.testing.expectEqual(@as(u32, 128), Fixed24_8.fromParts(0, 128).raw);
+    try std.testing.expectEqual(@as(i32, 128), Fixed24_8.fromFloat(0.5).raw);
+    try std.testing.expectEqual(@as(i32, 128), Fixed24_8.fromFraction(0, 1, 2).raw);
+    try std.testing.expectEqual(@as(i32, 128), Fixed24_8.fromParts(0, 128).raw);
 
     // 0.25 -> 64 (0x40)
-    try std.testing.expectEqual(@as(u32, 64), Fixed24_8.fromFloat(0.25).raw);
-    try std.testing.expectEqual(@as(u32, 64), Fixed24_8.fromFraction(0, 1, 4).raw);
+    try std.testing.expectEqual(@as(i32, 64), Fixed24_8.fromFloat(0.25).raw);
+    try std.testing.expectEqual(@as(i32, 64), Fixed24_8.fromFraction(0, 1, 4).raw);
 
     // 0.75 -> 192 (0xC0)
-    try std.testing.expectEqual(@as(u32, 192), Fixed24_8.fromFloat(0.75).raw);
-    try std.testing.expectEqual(@as(u32, 192), Fixed24_8.fromFraction(0, 3, 4).raw);
+    try std.testing.expectEqual(@as(i32, 192), Fixed24_8.fromFloat(0.75).raw);
+    try std.testing.expectEqual(@as(i32, 192), Fixed24_8.fromFraction(0, 3, 4).raw);
 
     // 0.125 -> 32 (0x20)
-    try std.testing.expectEqual(@as(u32, 32), Fixed24_8.fromFloat(0.125).raw);
-    try std.testing.expectEqual(@as(u32, 32), Fixed24_8.fromFraction(0, 1, 8).raw);
+    try std.testing.expectEqual(@as(i32, 32), Fixed24_8.fromFloat(0.125).raw);
+    try std.testing.expectEqual(@as(i32, 32), Fixed24_8.fromFraction(0, 1, 8).raw);
 
     // 0.375 -> 96 (0x60)
-    try std.testing.expectEqual(@as(u32, 96), Fixed24_8.fromFloat(0.375).raw);
-    try std.testing.expectEqual(@as(u32, 96), Fixed24_8.fromFraction(0, 3, 8).raw);
+    try std.testing.expectEqual(@as(i32, 96), Fixed24_8.fromFloat(0.375).raw);
+    try std.testing.expectEqual(@as(i32, 96), Fixed24_8.fromFraction(0, 3, 8).raw);
 
     // 0.625 -> 160 (0xA0)
-    try std.testing.expectEqual(@as(u32, 160), Fixed24_8.fromFloat(0.625).raw);
-    try std.testing.expectEqual(@as(u32, 160), Fixed24_8.fromFraction(0, 5, 8).raw);
+    try std.testing.expectEqual(@as(i32, 160), Fixed24_8.fromFloat(0.625).raw);
+    try std.testing.expectEqual(@as(i32, 160), Fixed24_8.fromFraction(0, 5, 8).raw);
 
     // 0.875 -> 224 (0xE0)
-    try std.testing.expectEqual(@as(u32, 224), Fixed24_8.fromFloat(0.875).raw);
-    try std.testing.expectEqual(@as(u32, 224), Fixed24_8.fromFraction(0, 7, 8).raw);
+    try std.testing.expectEqual(@as(i32, 224), Fixed24_8.fromFloat(0.875).raw);
+    try std.testing.expectEqual(@as(i32, 224), Fixed24_8.fromFraction(0, 7, 8).raw);
 
     // Verify integer + fraction combinations
     // 12.75 -> (12 << 8) + 192
-    try std.testing.expectEqual(@as(u32, (12 << 8) + 192), Fixed24_8.fromFloat(12.75).raw);
-    try std.testing.expectEqual(@as(u32, (12 << 8) + 192), Fixed24_8.fromFraction(12, 3, 4).raw);
+    try std.testing.expectEqual(@as(i32, (12 << 8) + 192), Fixed24_8.fromFloat(12.75).raw);
+    try std.testing.expectEqual(@as(i32, (12 << 8) + 192), Fixed24_8.fromFraction(12, 3, 4).raw);
 }

--- a/src/engine/sprite.zig
+++ b/src/engine/sprite.zig
@@ -93,8 +93,8 @@ pub const CollisionResult = struct {
 /// High-level Sprite with unified AABB bounding box and velocity physics.
 pub const Sprite = struct {
     aabb: AABB,
-    velocity_x: i32 = 0, // 24.8 signed fixed-point velocity
-    velocity_y: i32 = 0, // 24.8 signed fixed-point velocity
+    velocity_x: Fixed24_8 = Fixed24_8.zero,
+    velocity_y: Fixed24_8 = Fixed24_8.zero,
 
     /// 16-bit collision layer (self classification)
     layer: CollisionMask = Collision.NONE,
@@ -120,7 +120,7 @@ pub const Sprite = struct {
     visible: bool = true,
 
     /// Initialize a Sprite with integer pixel coordinates and dimensions.
-    pub fn init(x: u32, y: u32, width: u16, height: u16) Sprite {
+    pub fn init(x: i32, y: i32, width: u16, height: u16) Sprite {
         return .{
             .aabb = AABB.fromInt(x, y, width, height),
         };
@@ -134,7 +134,7 @@ pub const Sprite = struct {
     }
 
     /// Initializes a sprite and verifies its width and height are valid GBA sprite dimensions.
-    pub fn initChecked(x: u32, y: u32, width: u16, height: u16) SpriteError!Sprite {
+    pub fn initChecked(x: i32, y: i32, width: u16, height: u16) SpriteError!Sprite {
         _ = try getShapeAndSize(width, height);
         return init(x, y, width, height);
     }
@@ -150,30 +150,26 @@ pub const Sprite = struct {
         var result = CollisionResult{};
 
         // 1. Move along X axis
-        if (self.velocity_x != 0) {
-            const next_raw = @as(i64, self.aabb.x.raw) + self.velocity_x;
-            const clamped_raw: u32 = if (next_raw < 0) 0 else @as(u32, @intCast(next_raw));
-            const next_x = Fixed24_8{ .raw = clamped_raw };
+        if (self.velocity_x.raw != 0) {
+            const next_x = self.aabb.x.add(self.velocity_x);
             const test_box_x = AABB.init(next_x, self.aabb.y, self.aabb.width, self.aabb.height);
 
-            if (next_raw < 0 or collision_map.isColliding(test_box_x)) {
+            if (next_x.raw < 0 or collision_map.isColliding(test_box_x)) {
                 result.collided_x = true;
-                self.velocity_x = 0;
+                self.velocity_x = Fixed24_8.zero;
             } else {
                 self.aabb.x = next_x;
             }
         }
 
         // 2. Move along Y axis
-        if (self.velocity_y != 0) {
-            const next_raw = @as(i64, self.aabb.y.raw) + self.velocity_y;
-            const clamped_raw: u32 = if (next_raw < 0) 0 else @as(u32, @intCast(next_raw));
-            const next_y = Fixed24_8{ .raw = clamped_raw };
+        if (self.velocity_y.raw != 0) {
+            const next_y = self.aabb.y.add(self.velocity_y);
             const test_box_y = AABB.init(self.aabb.x, next_y, self.aabb.width, self.aabb.height);
 
-            if (next_raw < 0 or collision_map.isColliding(test_box_y)) {
+            if (next_y.raw < 0 or collision_map.isColliding(test_box_y)) {
                 result.collided_y = true;
-                self.velocity_y = 0;
+                self.velocity_y = Fixed24_8.zero;
             } else {
                 self.aabb.y = next_y;
             }
@@ -374,12 +370,12 @@ test "SPR007: Sprite moveAndCollide stops against map obstacles" {
 
     // Sprite at x=8, y=0, size 8x8 (tile 1, 0)
     var spr = Sprite.init(8, 0, 8, 8);
-    spr.velocity_x = 8 << 8; // Move right by 8 pixels per step
+    spr.velocity_x = Fixed24_8.fromInt(8); // Move right by 8 pixels per step
 
     // Step 1: Moves from x=8 to x=16 (tile 2) -> Clear
     var res = spr.moveAndCollide(map);
     try std.testing.expect(!res.hasCollided());
-    try std.testing.expectEqual(@as(u32, 16), spr.aabb.x.toInt());
+    try std.testing.expectEqual(@as(i32, 16), spr.aabb.x.toInt());
 
     // Step 2: Next step would move from x=16 to x=24 (tile 3, which is solid) -> Collision!
     res = spr.moveAndCollide(map);
@@ -387,15 +383,15 @@ test "SPR007: Sprite moveAndCollide stops against map obstacles" {
     try std.testing.expect(!res.collided_y);
     try std.testing.expect(res.hasCollided());
     // Position should NOT have advanced into the wall
-    try std.testing.expectEqual(@as(u32, 16), spr.aabb.x.toInt());
+    try std.testing.expectEqual(@as(i32, 16), spr.aabb.x.toInt());
     // Velocity on X is stopped (zeroed out)
-    try std.testing.expectEqual(@as(i32, 0), spr.velocity_x);
+    try std.testing.expectEqual(Fixed24_8.zero.raw, spr.velocity_x.raw);
 
     // Step 3: Test negative velocity (moving left)
-    spr.velocity_x = -(8 << 8);
+    spr.velocity_x = Fixed24_8.fromInt(-8);
     res = spr.moveAndCollide(map);
     try std.testing.expect(!res.hasCollided());
-    try std.testing.expectEqual(@as(u32, 8), spr.aabb.x.toInt());
+    try std.testing.expectEqual(@as(i32, 8), spr.aabb.x.toInt());
 }
 
 test "SPR008: Sprite collision via AABB" {


### PR DESCRIPTION
## Summary
- Migrate `Fixed24_8` underlying storage from `raw: u32` to `raw: i32` (signed 24.8 fixed-point).
- Update `Sprite.velocity_x` and `velocity_y` from raw integer `i32` to `Fixed24_8` for type safety and consistency.
- Add convenience constructors and operations: `.zero`, `.neg()`, `fromFloat()`, `fromInt()`.
- Adapt `AABB` and demo ROMs (`collision_demo`, `flappy_tsetseg`, `pong`) to use `Fixed24_8` APIs instead of magic bit-shifts.
- Add documentation chapter in `docs/fixed_number.md` explaining the design decisions and screen coordinate/OAM implications.

## Validation
- `zig build test`: 102/102 unit tests pass.
- `zig build coverage`: 98.20% engine / 95.70% zurag coverage.
- `zig build`: All ROM binaries compile without warnings.